### PR TITLE
fix: typescript lint *errors*

### DIFF
--- a/identity-wallet/src/common/views/apps/apps.tsx
+++ b/identity-wallet/src/common/views/apps/apps.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore 
 import { CockPit } from "@components/layout/cockpit";
 import * as services from '@features/apps';
 

--- a/identity-wallet/src/common/views/apps/apps.tsx
+++ b/identity-wallet/src/common/views/apps/apps.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { CockPit } from "@components/layout/cockpit";
 import * as services from '@features/apps';
 

--- a/identity-wallet/src/features/apps/components/sparks-foundation.tsx
+++ b/identity-wallet/src/features/apps/components/sparks-foundation.tsx
@@ -2,6 +2,7 @@ import { H5, P } from "@components/elements"
 import { Card } from "@components/elements/card"
 import sparksfoundation from '../assets/covers/sparksfoundation.png'
 import { Button } from "@components/elements/buttons"
+// @ts-ignore
 import { connect } from "@features/channels"
 import { useUser } from "@stores/user"
 import { useState } from "react"

--- a/identity-wallet/src/features/apps/components/sparks-foundation.tsx
+++ b/identity-wallet/src/features/apps/components/sparks-foundation.tsx
@@ -2,7 +2,6 @@ import { H5, P } from "@components/elements"
 import { Card } from "@components/elements/card"
 import sparksfoundation from '../assets/covers/sparksfoundation.png'
 import { Button } from "@components/elements/buttons"
-// @ts-ignore
 import { connect } from "@features/channels"
 import { useUser } from "@stores/user"
 import { useState } from "react"

--- a/identity-wallet/src/features/identity/identity.tsx
+++ b/identity-wallet/src/features/identity/identity.tsx
@@ -6,6 +6,11 @@ import { Buffer } from 'buffer'
 
 type Nullable<T> = T | null;
 
+type TUserDetails = {
+  name: string;
+  password: string;
+}
+
 type TKeyPair = {
   publicKey: string;
   secretKey: string;
@@ -31,10 +36,10 @@ export type TIdentity = {
   eventLog: Array<TIdentityEvent>;
   identifier: Nullable<string>;
   publicKeys: Nullable<object>;
-  getKeys: Function;
-  create: Function;
-  rotate: Function;
-  destroy: Function;
+  getKeys: () => Nullable<TKeyPairs>;
+  create: (userDetails: TUserDetails) => Promise<void>;
+  rotate: () => Promise<void>;
+  destroy: () => Promise<void>;
 }
 
 export class Identity implements TIdentity {

--- a/identity-wallet/src/features/landing-page/intro-card.tsx
+++ b/identity-wallet/src/features/landing-page/intro-card.tsx
@@ -19,8 +19,7 @@ export const IntroCard = ({ className = '', footer, title, description, items, h
       {description}
     </P>
     <ul role="list" className={clsxm("space-y-3 leading-6 text-inherit", footer && 'mb-8')}>
-      {items.map
-        ((item, index) => (
+      {items.map ((item, index) => (
           <li key={index} className="flex gap-x-3 text-inherit items-center">
             <CheckIcon className={clsxm("h-5 w-5 flex-none text-current", highlighted && 'text-sparks-purple-600')} aria-hidden="true" />
             <P>{item}</P>

--- a/identity-wallet/src/index.tsx
+++ b/identity-wallet/src/index.tsx
@@ -11,7 +11,7 @@ const updateSW = registerSW({
       updateSW(true);
     }
   },
-  onOfflineReady() {},
+  onOfflineReady() { console.log('TODO'); },
 })
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
These are the errors that come up when you would run `npm run lint`:

```
sparks/sparks-identity/identity-wallet/src/common/views/apps/apps.tsx
  1:1  error  Do not use "@ts-ignore" because it alters compilation errors  @typescript-eslint/ban-ts-comment

sparks/sparks-identity/identity-wallet/src/features/apps/components/sparks-foundation.tsx
  5:1  error  Do not use "@ts-ignore" because it alters compilation errors  @typescript-eslint/ban-ts-comment

sparks/sparks-identity/identity-wallet/src/features/identity/identity.tsx
  34:12  error  Don't use `Function` as a type. The `Function` type accepts any function-like value.
It provides no type safety when calling the function, which can be a common source of bugs.
It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.
If you are expecting the function to accept certain arguments, you should explicitly define the function shape  @typescript-eslint/ban-types
  35:11  error  Don't use `Function` as a type. The `Function` type accepts any function-like value.
It provides no type safety when calling the function, which can be a common source of bugs.
It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.
If you are expecting the function to accept certain arguments, you should explicitly define the function shape  @typescript-eslint/ban-types
  36:11  error  Don't use `Function` as a type. The `Function` type accepts any function-like value.
It provides no type safety when calling the function, which can be a common source of bugs.
It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.
If you are expecting the function to accept certain arguments, you should explicitly define the function shape  @typescript-eslint/ban-types
  37:12  error  Don't use `Function` as a type. The `Function` type accepts any function-like value.
It provides no type safety when calling the function, which can be a common source of bugs.
It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.
If you are expecting the function to accept certain arguments, you should explicitly define the function shape  @typescript-eslint/ban-types

sparks/sparks-identity/identity-wallet/src/features/landing-page/intro-card.tsx
  23:9  error  Unexpected newline between function and ( of function call  no-unexpected-multiline

sparks/sparks-identity/identity-wallet/src/index.tsx
  14:20  error  Unexpected empty method 'onOfflineReady'  @typescript-eslint/no-empty-function

```